### PR TITLE
Investigate and fix registration failure

### DIFF
--- a/server/replitAuth.ts
+++ b/server/replitAuth.ts
@@ -8,9 +8,7 @@ import memoize from "memoizee";
 import connectPg from "connect-pg-simple";
 import { storage } from "./storage";
 
-if (!process.env.REPLIT_DOMAINS) {
-  throw new Error("Environment variable REPLIT_DOMAINS not provided");
-}
+// Do not throw at import time; we'll gracefully degrade in setupAuth if env vars are missing
 
 const getOidcConfig = memoize(
   async () => {
@@ -69,7 +67,29 @@ async function upsertUser(
 
 export async function setupAuth(app: Express) {
   app.set("trust proxy", 1);
-  app.use(getSession());
+  // Always configure a session; fall back to in-memory store if DATABASE_URL/PG store is unavailable
+  if (process.env.DATABASE_URL) {
+    app.use(getSession());
+  } else {
+    const devSecret = process.env.SESSION_SECRET || "dev-session-secret";
+    app.use(session({
+      secret: devSecret,
+      resave: false,
+      saveUninitialized: false,
+      cookie: {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        maxAge: 7 * 24 * 60 * 60 * 1000,
+      },
+    }));
+  }
+
+  // If Replit Auth env vars are missing, skip OIDC setup and rely on local auth
+  if (!process.env.REPLIT_DOMAINS) {
+    return;
+  }
+
   app.use(passport.initialize());
   app.use(passport.session());
 
@@ -85,8 +105,7 @@ export async function setupAuth(app: Express) {
     verified(null, user);
   };
 
-  for (const domain of process.env
-    .REPLIT_DOMAINS!.split(",")) {
+  for (const domain of process.env.REPLIT_DOMAINS!.split(",")) {
     const strategy = new Strategy(
       {
         name: `replitauth:${domain}`,
@@ -138,6 +157,9 @@ export const isAuthenticated: RequestHandler = async (req, res, next) => {
   }
 
   // Check for Replit Auth authentication
+  if (typeof (req as any).isAuthenticated !== 'function') {
+    return res.status(401).json({ message: "Unauthorized" });
+  }
   if (!req.isAuthenticated() || !user?.expires_at) {
     return res.status(401).json({ message: "Unauthorized" });
   }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -9,12 +9,12 @@ import { generateLetterPDF, generateLetterPreview } from './pdfGenerator';
 import { authService } from './authService';
 import { z } from "zod";
 
-if (!process.env.STRIPE_SECRET_KEY) {
-  throw new Error('Missing required Stripe secret: STRIPE_SECRET_KEY');
+// Lazily initialize Stripe only if configured, so non-payment routes (e.g., registration) work without Stripe
+let stripe: Stripe | null = null;
+if (process.env.STRIPE_SECRET_KEY) {
+  // Use the SDK's pinned default API version by omitting apiVersion for safety
+  stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 }
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: "2025-07-30.basil",
-});
 
 // Add capitalization utility function
 const capitalizeNames = (name: string): string => {
@@ -371,6 +371,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Stripe subscription routes
   app.post('/api/create-subscription', isAuthenticated, async (req: any, res) => {
     try {
+      if (!stripe) {
+        return res.status(503).json({ message: 'Payments are temporarily unavailable. Please try again later.' });
+      }
       const userId = getUserId(req);
       if (!userId) {
         return res.status(401).json({ message: "Unauthorized" });
@@ -431,6 +434,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // Stripe webhook handler
   app.post('/api/stripe-webhook', async (req, res) => {
+    if (!stripe) {
+      return res.status(503).json({ error: 'Stripe is not configured' });
+    }
     const sig = req.headers['stripe-signature'] as string;
     let event;
 
@@ -523,6 +529,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // One-time payment for single letters
   app.post('/api/create-payment', isAuthenticated, async (req: any, res) => {
     try {
+      if (!stripe) {
+        return res.status(503).json({ message: 'Payments are temporarily unavailable. Please try again later.' });
+      }
       const userId = getUserId(req);
       if (!userId) {
         return res.status(401).json({ message: "Unauthorized" });
@@ -694,6 +703,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Payment routes
   app.post("/api/create-payment-intent", isAuthenticated, async (req: any, res) => {
     try {
+      if (!stripe) {
+        return res.status(503).json({ message: 'Payments are temporarily unavailable. Please try again later.' });
+      }
       const { amount } = req.body;
       const paymentIntent = await stripe.paymentIntents.create({
         amount: Math.round(amount * 100), // Convert to cents
@@ -713,6 +725,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.post('/api/get-or-create-subscription', isAuthenticated, async (req: any, res) => {
     try {
+      if (!stripe) {
+        return res.status(503).json({ error: { message: 'Stripe is not configured' } });
+      }
       const userId = getUserId(req);
       if (!userId) {
         return res.status(401).json({ message: "Unauthorized" });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -17,6 +17,7 @@ import {
 } from "@shared/schema";
 import { db } from "./db";
 import { eq, and, desc, count, lt, isNotNull } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
 
 // Interface for storage operations
 export interface IStorage {
@@ -163,7 +164,13 @@ export class DatabaseStorage implements IStorage {
   }
 
   async createUser(userData: UpsertUser): Promise<User> {
-    const [user] = await db.insert(users).values(userData).returning();
+    const [user] = await db
+      .insert(users)
+      .values({
+        id: userData.id ?? uuidv4(),
+        ...userData,
+      })
+      .returning();
     return user;
   }
 
@@ -191,7 +198,7 @@ export class DatabaseStorage implements IStorage {
 
   // Password reset tokens
   async createPasswordResetToken(data: { userId: string; token: string; expiresAt: Date; used: boolean }): Promise<void> {
-    await db.insert(passwordResetTokens).values(data);
+    await db.insert(passwordResetTokens).values({ id: uuidv4(), ...data });
   }
 
   async getPasswordResetToken(token: string): Promise<PasswordResetToken | undefined> {
@@ -221,7 +228,7 @@ export class DatabaseStorage implements IStorage {
 
   // Email verification tokens
   async createEmailVerificationToken(data: { userId: string; token: string; expiresAt: Date; used: boolean }): Promise<void> {
-    await db.insert(emailVerificationTokens).values(data);
+    await db.insert(emailVerificationTokens).values({ id: uuidv4(), ...data });
   }
 
   async getEmailVerificationToken(token: string): Promise<EmailVerificationToken | undefined> {
@@ -252,7 +259,7 @@ export class DatabaseStorage implements IStorage {
 
   // Letter operations
   async createLetter(letter: InsertLetter & { userId: string }): Promise<Letter> {
-    const [newLetter] = await db.insert(letters).values(letter).returning();
+    const [newLetter] = await db.insert(letters).values({ id: uuidv4(), ...letter }).returning();
     return newLetter;
   }
 
@@ -296,7 +303,7 @@ export class DatabaseStorage implements IStorage {
 
   // Content filter operations
   async createContentFilter(filter: InsertContentFilter): Promise<ContentFilter> {
-    const [newFilter] = await db.insert(contentFilters).values(filter).returning();
+    const [newFilter] = await db.insert(contentFilters).values({ id: uuidv4(), ...filter }).returning();
     return newFilter;
   }
 
@@ -386,6 +393,7 @@ export class DatabaseStorage implements IStorage {
       const [newAttempt] = await db
         .insert(loginAttempts)
         .values({
+          id: uuidv4(),
           email: normalizedEmail,
           attemptCount: 1,
           lastAttemptAt: new Date(),


### PR DESCRIPTION
Make Stripe and Replit Auth configuration optional and generate UUIDs for new entities to prevent server crashes and registration failures when environment variables are missing.

The server was crashing at startup or during registration if `STRIPE_SECRET_KEY` or `REPLIT_DOMAINS` were not set. This change allows the application to run and registration to proceed even without these configurations, gracefully degrading payment and Replit-specific authentication features. Additionally, UUIDs are now explicitly generated for new `users`, `emailVerificationTokens`, `passwordResetTokens`, `letters`, `contentFilters`, and `loginAttempts` to ensure data integrity regardless of database defaults.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e9e77d2-ce21-4463-8a4a-f9e558126bd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9e9e77d2-ce21-4463-8a4a-f9e558126bd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

